### PR TITLE
Add versioning to PiCli FaaS calls

### DIFF
--- a/picli/configs/base_pipe.py
+++ b/picli/configs/base_pipe.py
@@ -165,3 +165,7 @@ class BasePipeConfig(object):
     @property
     def endpoint(self):
         return self.pipe_config[f'pi_{self.name}_pipe_vars']['url']
+
+    @property
+    def version(self):
+        return self.pipe_config[f'pi_{self.name}_pipe_vars']['version']

--- a/picli/configs/validate_pipe.py
+++ b/picli/configs/validate_pipe.py
@@ -36,12 +36,16 @@ class ValidatePipeConfig(BasePipeConfig):
         return self.pipe_config['pi_validate_pipe_vars']
 
     @property
-    def policy_checks_enforcing(self):
-        return self.pipe_vars['policy_checks']['enforcing']
+    def policy_enforcing(self):
+        return self.pipe_vars['policy']['enforcing']
 
     @property
-    def policy_checks_enabled(self):
-        return self.pipe_vars['policy_checks']['enabled']
+    def policy_enabled(self):
+        return self.pipe_vars['policy']['enabled']
+
+    @property
+    def policy_version(self):
+        return self.pipe_vars['policy']['version']
 
     def _validate(self):
         errors = validate_pipeconfig_schema.validate(self.pipe_config)

--- a/picli/linter/base.py
+++ b/picli/linter/base.py
@@ -80,7 +80,11 @@ class Base(object):
         Defines the URL of the function which the execute method will hit
         :return: string
         """
-        return self.config.endpoint + f'/piedpiper-{self.name}-function'
+        url_version_string = self.config.version.replace('.', '-')
+        if self.config.version == 'latest':
+            return f'{self.config.endpoint}/piedpiper-{self.name}-function'
+        else:
+            return f'{self.config.endpoint}/piedpiper-{self.name}-function-{url_version_string}'
 
     @abc.abstractmethod
     def zip_files(self, destination):

--- a/picli/model/lint_pipeconfig_schema.py
+++ b/picli/model/lint_pipeconfig_schema.py
@@ -7,6 +7,7 @@ from marshmallow import ValidationError
 class PiLintPipeVarsSchema(Schema):
     run_pipe = fields.Bool(required=True)
     url = fields.Str(required=True)
+    version = fields.Str(required=True)
 
 
 class LintPipeConfigSchema(Schema):

--- a/picli/model/validate_pipeconfig_schema.py
+++ b/picli/model/validate_pipeconfig_schema.py
@@ -4,15 +4,17 @@ from marshmallow import RAISE
 from marshmallow import ValidationError
 
 
-class PiPolicyChecksSchema(Schema):
+class PiPolicySchema(Schema):
     enabled = fields.Bool(required=True)
     enforcing = fields.Bool(required=True)
+    version = fields.Str(required=True)
 
 
 class PiValidatePipeVarsSchema(Schema):
     run_pipe = fields.Bool(required=True)
     url = fields.Str(required=True)
-    policy_checks = fields.Nested(PiPolicyChecksSchema)
+    version = fields.Str(required=True)
+    policy = fields.Nested(PiPolicySchema)
 
 
 class ValidatePipeConfigSchema(Schema):

--- a/picli/validators/validator.py
+++ b/picli/validators/validator.py
@@ -26,7 +26,7 @@ class Validator(object):
         Initialize the Validator.
         :param base_config: ValidatePipeConfig object
         """
-        self.base_config = base_config
+        self.config = base_config
 
     @property
     def name(self):
@@ -34,11 +34,15 @@ class Validator(object):
 
     @property
     def url(self):
-        return self.base_config.endpoint + f'/piedpiper-{self.name}-function'
+        url_version_string = self.config.version.replace('.', '-')
+        if self.config.version == 'latest':
+            return f'{self.config.endpoint}/piedpiper-{self.name}-function'
+        else:
+            return f'{self.config.endpoint}/piedpiper-{self.name}-function-{url_version_string}'
 
     @property
     def enabled(self):
-        return self.base_config.run_pipe
+        return self.config.run_pipe
 
     def zip_files(self, destination):
         """
@@ -50,7 +54,7 @@ class Validator(object):
             zip_file = zipfile.ZipFile(
                 f'{destination}/validation.zip', 'w', zipfile.ZIP_DEFLATED
             )
-            zip_file.writestr("run_vars.yml", self.base_config.dump_configs())
+            zip_file.writestr("run_vars.yml", self.config.dump_configs())
             zip_file.close()
             return zip_file
         except Exception as e:
@@ -91,7 +95,7 @@ class Validator(object):
                     if value['errors']:
                         result_list.append(stage_result)
         if len(result_list):
-            if self.base_config.policy_checks_enforcing:
+            if self.config.policy_enforcing:
                 util.sysexit_with_message(
                     json.dumps(result_list, indent=4)
                 )

--- a/tests/functional/cpp_and_python_project/.gitlab-ci.yml
+++ b/tests/functional/cpp_and_python_project/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 image: python:3.6
 
 stages:
+  - validate
   - lint
   - build
   - generate_docker_image_push_to_nexus

--- a/tests/functional/cpp_and_python_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_lint.yml
+++ b/tests/functional/cpp_and_python_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_lint.yml
@@ -1,3 +1,4 @@
 pi_lint_pipe_vars:
   run_pipe: true
   url: http://172.17.0.1:8080/function
+  version: latest

--- a/tests/functional/cpp_and_python_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_validate.yml
+++ b/tests/functional/cpp_and_python_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_validate.yml
@@ -1,6 +1,8 @@
 pi_validate_pipe_vars:
   run_pipe: true
   url: http://172.17.0.1:8080/function
-  policy_checks:
+  version: latest
+  policy:
+    version: 0.0.1
     enabled: true
     enforcing: true

--- a/tests/functional/cpp_project/.gitlab-ci.yml
+++ b/tests/functional/cpp_project/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 image: python:3.6
 
 stages:
+  - validate
   - lint
   - build
   - generate_docker_image_push_to_nexus

--- a/tests/functional/cpp_project/piedpiper.d/default_vars.d/group_vars.d/all.yml
+++ b/tests/functional/cpp_project/piedpiper.d/default_vars.d/group_vars.d/all.yml
@@ -2,4 +2,6 @@
 pi_lint:
   - name: "*"
     linter: noop
-
+pi_sast:
+  - name: "*"
+    sast: noop

--- a/tests/functional/cpp_project/piedpiper.d/default_vars.d/group_vars.d/python_lint.yml
+++ b/tests/functional/cpp_project/piedpiper.d/default_vars.d/group_vars.d/python_lint.yml
@@ -1,0 +1,4 @@
+---
+pi_lint:
+  - name: "*.py"
+    linter: flake8

--- a/tests/functional/cpp_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_lint.yml
+++ b/tests/functional/cpp_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_lint.yml
@@ -1,3 +1,4 @@
 pi_lint_pipe_vars:
   run_pipe: true
   url: http://172.17.0.1:8080/function
+  version: latest

--- a/tests/functional/cpp_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_setup.yml
+++ b/tests/functional/cpp_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_setup.yml
@@ -1,5 +1,0 @@
-pi_setup_pipe_vars:
-  run_pipe: true
-  policy_checks:
-    enabled: true
-    enforcing: true

--- a/tests/functional/cpp_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_validate.yml
+++ b/tests/functional/cpp_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_validate.yml
@@ -1,6 +1,8 @@
 pi_validate_pipe_vars:
   run_pipe: true
   url: http://172.17.0.1:8080/function
-  policy_checks:
+  version: latest
+  policy:
+    version: 0.0.0
     enabled: true
     enforcing: true

--- a/tests/functional/python_project/.gitlab-ci.yml
+++ b/tests/functional/python_project/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 image: python:3.6
 
 stages:
+  - validate
   - lint
   - build
   - generate_docker_image_push_to_nexus

--- a/tests/functional/python_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_lint.yml
+++ b/tests/functional/python_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_lint.yml
@@ -1,3 +1,4 @@
 pi_lint_pipe_vars:
   run_pipe: true
+  version: latest
   url: http://172.17.0.1:8080/function

--- a/tests/functional/python_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_setup.yml
+++ b/tests/functional/python_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_setup.yml
@@ -1,5 +1,0 @@
-pi_setup_pipe_vars:
-  run_pipe: true
-  policy_checks:
-    enabled: true
-    enforcing: true

--- a/tests/functional/python_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_validate.yml
+++ b/tests/functional/python_project/piedpiper.d/default_vars.d/pipe_vars.d/pi_validate.yml
@@ -1,6 +1,8 @@
 pi_validate_pipe_vars:
   run_pipe: true
   url: http://172.17.0.1:8080/function
-  policy_checks:
+  version: latest
+  policy:
     enabled: true
     enforcing: true
+    version: 0.0.0


### PR DESCRIPTION
This change allows for the user to specify version numbers for
each pipe and for the policy defined in the validator pipe.
This allows for granular control of the pipeline during periods
of heavy change to the Piedpiper services.

This change required modifications to the piedpiper-validator-faas
and an additional git repository. Please see the documentation
for piedpiper-validator-faas for more information on those changes.

In each pipe_vars.d file there is now a required `version` field
which expects a version number (symver) or `latest`. This correlates
to an OpenFaaS function with the same version. For example, the
pipe_vars.d/pi_lint.yml version of `0.0.1` will hit a url of
{self.config.endpoint}/piedpiper-{self.name}-function-0-0-1. When
targetting `latest` it will leave off the version number from the URL.

Additionally `pipe_vars.d/pi_validate.yml` has a new required version
field under the `policy` dict. This will be passed to the validator
FaaS in the run_vars and will be used to control which version of
the policy will be applied when running the validator pipe.

Example configuration files can be found under tests/functional