### PR TITLE
Add debug flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ pip install -r requirements.txt
 python setup.py install
 ```
 
+## Using
+
 To run PiCli:
 
 #### Execute a lint
@@ -46,10 +48,20 @@ picli --config path/to/your/repo/piedpier.d/pi_global_vars.yml lint
 picli --config path/to/your/repo/piedpier.d/pi_global_vars.yml validate
 ```
 
+### CLI Arguments
+
+**debug**
+```
+picli --debug validate
+```
+Debug will dump PiCli's run_vars to the screen during execution. This allows
+the user to validate PiCli's configuration that is being sent to the
+various functions. 
+
 ## Running the tests
 
 Currently we just have functional tests. These require an OpenFaaS installation. The test script
-can be found in tests/funcitonal/run-tests.sh
+can be found in tests/functional/run-tests.sh
 
 
 ## Deployment

--- a/picli/command/base.py
+++ b/picli/command/base.py
@@ -9,8 +9,9 @@ LOG = logger.get_logger(__name__)
 class Base(object):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, base_config):
+    def __init__(self, base_config, debug):
         self._base_config = base_config
+        self.debug = debug
 
     @abc.abstractmethod
     def execute(self):
@@ -21,11 +22,11 @@ class Base(object):
         LOG.info(message)
 
 
-def execute_subcommand(config, subcommand):
+def execute_subcommand(config, subcommand, debug):
     command_module = getattr(picli.command, subcommand)
     command = getattr(command_module, util.camelize(subcommand))
 
-    return command(config).execute()
+    return command(config, debug).execute()
 
 
 def get_sequence(step):

--- a/picli/command/lint.py
+++ b/picli/command/lint.py
@@ -9,12 +9,15 @@ LOG = logger.get_logger(__name__)
 
 
 class Lint(base.Base):
-    def __init__(self, base_config):
-        super(Lint, self).__init__(base_config)
+    def __init__(self, base_config, debug):
+        super(Lint, self).__init__(base_config, debug)
 
     def execute(self):
         self.print_info()
-        lint_pipe_config = LintPipeConfig(self._base_config)
+        lint_pipe_config = LintPipeConfig(self._base_config, self.debug)
+        if self.debug:
+            message = f'Debugging run_vars\n\n{lint_pipe_config.dump_configs()}'
+            LOG.info(message)
         if lint_pipe_config.run_pipe:
             linters = set()
             for file in lint_pipe_config.run_config.files:
@@ -36,6 +39,7 @@ class Lint(base.Base):
 @click.pass_context
 def lint(context):
     config_file = context.obj.get('args')['config']
+    debug = context.obj.get('args')['debug']
     sequence = base.get_sequence('lint')
     for action in sequence:
-        base.execute_subcommand(config_file, action)
+        base.execute_subcommand(config_file, action, debug)

--- a/picli/command/sast.py
+++ b/picli/command/sast.py
@@ -9,12 +9,15 @@ LOG = logger.get_logger(__name__)
 
 
 class Sast(base.Base):
-    def __init__(self, base_config):
-        super(Sast, self).__init__(base_config)
+    def __init__(self, base_config, debug):
+        super(Sast, self).__init__(base_config, debug)
 
     def execute(self):
         self.print_info()
-        sast_pipe_config = SastPipeConfig(self._base_config)
+        sast_pipe_config = SastPipeConfig(self._base_config, self.debug)
+        if self.debug:
+            message = f'Debugging run_vars\n\n{sast_pipe_config.dump_configs()}'
+            LOG.info(message)
         if sast_pipe_config.run_pipe:
             sast_analyzers = set()
             for file in sast_pipe_config.run_config.files:
@@ -36,6 +39,7 @@ class Sast(base.Base):
 @click.pass_context
 def sast(context):
     config_file = context.obj.get('args')['config']
+    debug = context.obj.get('args')['debug']
     sequence = base.get_sequence('sast')
     for action in sequence:
-        base.execute_subcommand(config_file, action)
+        base.execute_subcommand(config_file, action, debug)

--- a/picli/command/validate.py
+++ b/picli/command/validate.py
@@ -11,7 +11,10 @@ class Validate(base.Base):
 
     def execute(self):
         self.print_info()
-        validator_config = ValidatePipeConfig(self._base_config)
+        validator_config = ValidatePipeConfig(self._base_config, self.debug)
+        if self.debug:
+            message = f'Debugging run_vars\n\n{validator_config.dump_configs()}'
+            LOG.info(message)
         if validator_config.run_pipe:
             validator = Validator(validator_config)
             validator.execute()
@@ -23,6 +26,7 @@ class Validate(base.Base):
 @click.pass_context
 def validate(context):
     config_file = context.obj.get('args')['config']
+    debug = context.obj.get('args')['debug']
     sequence = base.get_sequence('validate')
     for action in sequence:
-        base.execute_subcommand(config_file, action)
+        base.execute_subcommand(config_file, action, debug)

--- a/picli/config.py
+++ b/picli/config.py
@@ -9,9 +9,10 @@ LOG = logger.get_logger(__name__)
 
 class BaseConfig(object):
 
-    def __init__(self, config):
+    def __init__(self, config, debug):
         self.base_path = self._find_base_dir(config)
         self.config = self._read_config(config)
+        self.debug = debug
         self._validate()
 
     def _find_base_dir(self, config):

--- a/picli/configs/base_pipe.py
+++ b/picli/configs/base_pipe.py
@@ -16,13 +16,13 @@ class BasePipeConfig(object):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, base_config):
+    def __init__(self, base_config, debug):
         """
         Builds a BaseConfig object, run configurations,
         and a pipe_config based on the subclasses' name attr.
         :param base_config:
         """
-        self.base_config = BaseConfig(base_config)
+        self.base_config = BaseConfig(base_config, debug)
         self.run_config = self._build_run_config()
         self.pipe_config = self._build_pipe_config()
 
@@ -173,6 +173,10 @@ class BasePipeConfig(object):
         return merged_run_config
 
     @property
+    def debug(self):
+        return self.base_config.debug
+
+    @property
     @abc.abstractmethod
     def name(self):
         pass
@@ -188,3 +192,11 @@ class BasePipeConfig(object):
     @property
     def version(self):
         return self.pipe_config[f'pi_{self.name}_pipe_vars']['version']
+
+    def dump_configs(self):
+        run_config = {}
+        file_config = [file for file in self.run_config.files]
+        util.merge_dicts(run_config, {'file_config': file_config})
+        util.merge_dicts(run_config, self.base_config.config)
+        util.merge_dicts(run_config, self.pipe_config)
+        return util.safe_dump(run_config)

--- a/picli/configs/lint_pipe.py
+++ b/picli/configs/lint_pipe.py
@@ -24,13 +24,13 @@ class LintPipeConfig(BasePipeConfig):
         {base_dir}/piedpiper.d/{vars_dir}/pipe_vars.d/pi_lint.yml
     """
 
-    def __init__(self, base_config):
+    def __init__(self, base_config, debug):
         """
         Call the superclass init to build BaseConfig object,
         pipe_configs, and run_configs, then validate.
         :param base_config:
         """
-        super(LintPipeConfig, self).__init__(base_config)
+        super(LintPipeConfig, self).__init__(base_config, debug)
         self._validate()
 
     @property
@@ -42,11 +42,3 @@ class LintPipeConfig(BasePipeConfig):
         if errors:
             msg = f"Failed to validate Lint Pipe Config. \n\n{errors.messages}"
             util.sysexit_with_message(msg)
-
-    def _dump_configs(self):
-        """
-        Dump file configurations in the LintPipe's run configuration
-        :return: Iterator
-        """
-        for lint_config in self.run_configs:
-            yield util.safe_dump(lint_config.files)

--- a/picli/configs/sast_pipe.py
+++ b/picli/configs/sast_pipe.py
@@ -24,13 +24,13 @@ class SastPipeConfig(BasePipeConfig):
         {base_dir}/piedpiper.d/{vars_dir}/pipe_vars.d/pi_lint.yml
     """
 
-    def __init__(self, base_config):
+    def __init__(self, base_config, debug):
         """
         Call the superclass init to build BaseConfig object,
         pipe_configs, and run_configs, then validate.
         :param base_config:
         """
-        super(SastPipeConfig, self).__init__(base_config)
+        super(SastPipeConfig, self).__init__(base_config, debug)
         self._validate()
 
     @property
@@ -42,11 +42,3 @@ class SastPipeConfig(BasePipeConfig):
         if errors:
             msg = f"Failed to validate SAST Pipe Config. \n\n{errors.messages}"
             util.sysexit_with_message(msg)
-
-    def _dump_configs(self):
-        """
-        Dump file configurations in the LintPipe's run configuration
-        :return: Iterator
-        """
-        for sast_config in self.run_configs:
-            yield util.safe_dump(sast_config.files)

--- a/picli/configs/validate_pipe.py
+++ b/picli/configs/validate_pipe.py
@@ -18,13 +18,13 @@ class ValidatePipeConfig(BasePipeConfig):
     Subclasses BasePipeConfig.
     """
 
-    def __init__(self, base_config):
+    def __init__(self, base_config, debug):
         """
         Initialize a ValidatePipeConfig object and returns None.
         :param base_config:
         """
-        super(ValidatePipeConfig, self).__init__(base_config)
-        self.pipe_configs = self._build_pipe_configs(base_config)
+        super(ValidatePipeConfig, self).__init__(base_config, debug)
+        self.pipe_configs = self._build_pipe_configs(base_config, debug)
         self._validate()
 
     @property
@@ -68,7 +68,7 @@ class ValidatePipeConfig(BasePipeConfig):
                 )
         }
 
-    def _build_pipe_configs(self, base_config):
+    def _build_pipe_configs(self, base_config, debug):
         """
         Builds a list of PipeConfig objects based on
         the contents of the picli.configs package directory so
@@ -86,7 +86,7 @@ class ValidatePipeConfig(BasePipeConfig):
         for pipe in pipes:
             pipe_config_module = getattr(importlib.import_module(f'picli.configs.{pipe}'),
                                          f'{util.camelize(pipe)}Config')
-            pipe_config = pipe_config_module(base_config)
+            pipe_config = pipe_config_module(base_config, debug)
             yield pipe_config
 
     def dump_configs(self):

--- a/picli/linter/base.py
+++ b/picli/linter/base.py
@@ -62,6 +62,8 @@ class Base(object):
             with open(zip_file.filename, 'rb') as file:
                 files = [('files', file)]
                 try:
+                    if self.config.debug:
+                        LOG.info(f'Sending zipfile to {self.url}')
                     r = requests.post(self.url, files=files)
                 except requests.exceptions.RequestException as e:
                     message = f"Failed to execute linter {self.name}. \n\n{e}"
@@ -100,6 +102,9 @@ class Base(object):
         )
         for file in self.run_config.files:
             if file['linter'] == f'{self.name}':
+                if self.config.debug:
+                    message = f'Writing {file["file"]} to zip'
+                    LOG.info(message)
                 zip_file.write(
                     f"{self.config.base_config.base_dir}/{file['file']}",
                     file['file']

--- a/picli/sast/base.py
+++ b/picli/sast/base.py
@@ -62,6 +62,8 @@ class Base(object):
             with open(zip_file.filename, 'rb') as file:
                 files = [('files', file)]
                 try:
+                    if self.config.debug:
+                        LOG.info(f'Sending zipfile to {self.url}')
                     r = requests.post(self.url, files=files)
                 except requests.exceptions.RequestException as e:
                     message = f"Failed to execute SAST analyzer {self.name}. \n\n{e}"
@@ -96,6 +98,9 @@ class Base(object):
         )
         for file in self.run_config.files:
             if file['sast'] == f'{self.name}':
+                if self.config.debug:
+                    message = f'Writing file: {file["file"]} to zip archive'
+                    LOG.info(message)
                 zip_file.write(
                     f"{self.config.base_config.base_dir}/{file['file']}",
                     file['file']

--- a/picli/shell.py
+++ b/picli/shell.py
@@ -10,11 +10,18 @@ from picli import command
     default='piedpiper.d/pi_global_vars.yml',
     help='The PiCli configuration file to use'
 )
+@click.option(
+    '--debug',
+    is_flag=True,
+    default=False,
+    help='Enable debug logging'
+)
 @click.pass_context
-def main(context, config):
+def main(context, config, debug):
     context.obj = {}
     context.obj['args'] = {}
     context.obj['args']['config'] = config
+    context.obj['args']['debug'] = debug
 
 
 main.add_command(command.lint.lint)

--- a/tests/functional/run-tests.sh
+++ b/tests/functional/run-tests.sh
@@ -6,5 +6,5 @@ for project in \
     python_project; do
 
     echo "Running picli on project $project in $(dirname $0)/$project"
-    picli --config $(dirname $0)/$project/piedpiper.d/pi_global_vars.yml lint
+    picli --config $(dirname $0)/$project/piedpiper.d/pi_global_vars.yml --debug lint
 done


### PR DESCRIPTION
This commit adds a --debug flag which can be provided
to dump additional debug information when running PiCli.

The debug flag is passed to each config object and can be
called from anywhere in PiCli. This can and show be extended
in the future.